### PR TITLE
Now Without log-in user can't navigate to bottom navigation page

### DIFF
--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 ///Project Local Imports
@@ -14,6 +15,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   void initState() {
     _scaffoldKey = new GlobalKey<ScaffoldState>();
+    FirebaseAuth.instance.signOut();
     super.initState();
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

In the case of email and password auth, if the user came from the sign-up-additional-page to the log-in page and if close the app and reopen the app, without log-in even without registered email verification, the user can navigate to the bottom navigation page... That breaks auth.... I improve it.... Without proper log-in user can't navigate to bottom navigation page.....

## Fixes #101 

Replace `#101` with the issue number which is fixed in this PR

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.

I don't know how to add a screenshot for that bug fix..... Sorry.... But my change works properly...

Hope you review it and merge it soon .... Thanks @HimeshNayak  @avinashkranjan 
