### PR TITLE
modified: CircleAvatar Widget

### DIFF
--- a/lib/widgets/header.dart
+++ b/lib/widgets/header.dart
@@ -41,11 +41,10 @@ class Header extends StatelessWidget {
                   ),
                   CircleAvatar(
                     radius: 25.0,
-                    backgroundImage: _userInfo.user != null &&
-                            _userInfo.user.profilePictureUrl.isNotEmpty
-                        ? NetworkImage(_userInfo.user.profilePictureUrl)
-                        : AssetImage("assets/images/profile_pic.jpg"),
-                  ),
+                      backgroundImage: _userInfo.user != null && _userInfo.user.profilePictureUrl.isNotEmpty
+                      ? NetworkImage(_userInfo.user.profilePictureUrl)
+                      : AssetImage("assets/images/profile_pic.jpg") as ImageProvider<Object>,
+                   ),
                 ],
               );
             },


### PR DESCRIPTION
# Description
In Flutter, the backgroundImage property of the CircleAvatar widget expects an ImageProvider type object. However, in our code, there is a mismatch between the expected type and the provided type.

![Screenshot 2023-05-23 225942](https://github.com/avinashkranjan/Friday/assets/121665385/6bdfda5a-92ca-4f46-a96a-b3701ab82e56)

To resolve this issue, we can explicitly typecast the AssetImage to ImageProvider using the "as" keyword. This tells Flutter to treat the AssetImage as an ImageProvider object, resolving the type mismatch error.

By making this modification, the code should run successfully, and the CircleAvatar will display the appropriate image based on the conditions we have set.

## Fixes #198 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

 [-] Yes
 [ ] No

## Type of change

_Please delete options that are not relevant._

 [-] Bug fix 

![Screenshot 2023-05-23 232809](https://github.com/avinashkranjan/Friday/assets/121665385/6d969bea-1205-482d-8e7e-2d1921fd13c3)

## Checklist:

- [-] My code follows the style guidelines(Clean Code) of this project
- [-] I have performed a self-review of my own code
- [-] My changes generate no new warnings
- [-] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
