### PR TITLE
 Removing Deprecated Splash Screen Implementation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,10 +34,6 @@
                  screen fades out. A splash screen is useful to avoid any visual
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
# Description

The <meta-data> code mentioned is part of the deprecated method for implementing a splash screen 

Result - 

![Screenshot 2023-06-24 155329](https://github.com/avinashkranjan/Friday/assets/121665385/409e0c0d-5a6e-4795-9b96-bd88534e25f4)

## Fixes #298 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

- Yes
- [ ] No

## Type of change

-  Bug fix

## Checklist:

-  My code follows the style guidelines(Clean Code) of this project
-  I have performed a self-review of my own code
-  My changes generate no new warnings
-  I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
