### PR TITLE
Removing deprecated version of backgroundColor

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,10 +37,10 @@ class MyApp extends StatelessWidget {
         title: 'Friday',
         theme: ThemeData(
           primaryColor: Color(0xFF202328),
-          backgroundColor: Color(0xFF12171D),
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-          colorScheme:
-              ColorScheme.fromSwatch().copyWith(secondary: Color(0xFF651FFF)),
+          visualDensity: VisualDensity.adaptivePlatformDensity, 
+          colorScheme: ColorScheme.fromSwatch().copyWith(
+            secondary: Color(0xFF651FFF)).copyWith(
+              background: Color(0xFF12171D)),
         ),
         home: FutureBuilder(
           future: Future.delayed(Duration(seconds: 3)),

--- a/lib/screens/alert_screen.dart
+++ b/lib/screens/alert_screen.dart
@@ -10,7 +10,7 @@ class _AlertScreenState extends State<AlertScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor.withOpacity(0.8),
+      backgroundColor: Theme.of(context).colorScheme.background.withOpacity(0.8),
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(

--- a/lib/screens/classes_screen.dart
+++ b/lib/screens/classes_screen.dart
@@ -48,7 +48,7 @@ class _ClassesScreenState extends State<ClassesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        backgroundColor: Theme.of(context).backgroundColor,
+        backgroundColor: Theme.of(context).colorScheme.background,
         floatingActionButton: floatingActionButtonCall(),
         body: ListView(
           children: [
@@ -111,7 +111,7 @@ class _ClassesScreenState extends State<ClassesScreen> {
           _mode = mode!;
         });
       },
-      dropdownColor: Theme.of(context).backgroundColor,
+      dropdownColor: Theme.of(context).colorScheme.background,
       decoration: dropdownDecoration.copyWith(
         labelText: "Mode",
       ),
@@ -123,7 +123,7 @@ class _ClassesScreenState extends State<ClassesScreen> {
         context: context,
         builder: (_) {
           return AlertDialog(
-            backgroundColor: Theme.of(context).backgroundColor,
+            backgroundColor: Theme.of(context).colorScheme.background,
             elevation: 5.0,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20.0),
@@ -298,7 +298,7 @@ class _ClassesScreenState extends State<ClassesScreen> {
                       alignment: Alignment.center,
                       child: ElevatedButton(
                         style: ElevatedButton.styleFrom(
-                          primary: Colors.green,
+                          backgroundColor: Colors.green,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(40.0),
                           ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -467,8 +467,7 @@ class DataSearch extends SearchDelegate<String> {
       style: ElevatedButton.styleFrom(
         shape: CircleBorder(
           side: BorderSide(color: Theme.of(context).colorScheme.secondary),
-        ),
-        primary: homework.isDone
+        ), backgroundColor: homework.isDone
             ? Theme.of(context).colorScheme.secondary
             : Colors.transparent,
       ),

--- a/lib/screens/homework_screen.dart
+++ b/lib/screens/homework_screen.dart
@@ -10,7 +10,7 @@ class _HomeworkScreenState extends State<HomeworkScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor.withOpacity(0.8),
+      backgroundColor: Theme.of(context).colorScheme.background.withOpacity(0.8),
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(

--- a/lib/screens/loading_screen.dart
+++ b/lib/screens/loading_screen.dart
@@ -144,7 +144,7 @@ class _LoadingScreenState extends State<LoadingScreen>
       bottomNavigationBar: Container(
         // height: 100, //0.1 * MediaQuery.of(context).size.height,
         decoration: BoxDecoration(
-          color: Theme.of(context).backgroundColor,
+          color: Theme.of(context).colorScheme.background,
           borderRadius: BorderRadius.only(
             topLeft: Radius.circular(30.0),
             topRight: Radius.circular(30.0),

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -22,7 +22,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       key: _scaffoldKey,
       body: SafeArea(
         child: Stack(

--- a/lib/screens/onboarding_page.dart
+++ b/lib/screens/onboarding_page.dart
@@ -19,7 +19,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Container(
           height: MediaQuery.of(context).size.height,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -71,7 +71,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor.withOpacity(0.8),
+      backgroundColor: Theme.of(context).colorScheme.background.withOpacity(0.8),
       body: SingleChildScrollView(
         physics: AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
         child: Consumer<UserInfoServices>(
@@ -256,11 +256,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 }
                               },
                               style: OutlinedButton.styleFrom(
-                                side: BorderSide(color: Colors.red),
+                                foregroundColor: Colors.transparent, side: BorderSide(color: Colors.red),
                                 padding: EdgeInsets.symmetric(
                                     horizontal: 20, vertical: 10),
                                 shape: StadiumBorder(),
-                                primary: Colors.transparent,
                               ),
                               child: Text(
                                 "Log out",
@@ -286,7 +285,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       ? NetworkImage(currentUser['profilePictureUrl'])
                       : AssetImage("assets/images/profile_pic.jpg") as ImageProvider<Object>?,
                     backgroundColor: Colors.transparent,
-                    foregroundColor: Theme.of(context).backgroundColor,
+                    foregroundColor: Theme.of(context).colorScheme.background,
                   ),
                 ),
                 Positioned(

--- a/lib/screens/signup_additional_details_screen.dart
+++ b/lib/screens/signup_additional_details_screen.dart
@@ -24,7 +24,7 @@ class _SignUpAdditionalDetailsState extends State<SignUpAdditionalDetails> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       key: _scaffoldKey,
       body: SafeArea(
         child: Stack(

--- a/lib/screens/signup_page.dart
+++ b/lib/screens/signup_page.dart
@@ -20,7 +20,7 @@ class _SignUpPageState extends State<SignUpPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       key: _scaffoldKey,
       body: SafeArea(
         child: Stack(

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -31,7 +31,7 @@ class _SplashScreenState extends State<SplashScreen>
   Widget build(BuildContext context) {
     final splashController = SplashAnimation(_controller);
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Container(
           height: MediaQuery.of(context).size.height,

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -28,7 +28,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
               height: MediaQuery.of(context).size.height - 100,
               width: MediaQuery.of(context).size.width,
               decoration: BoxDecoration(
-                color: Theme.of(context).backgroundColor,
+                color: Theme.of(context).colorScheme.background,
                 borderRadius: BorderRadius.only(
                   bottomLeft: Radius.circular(50.0),
                   bottomRight: Radius.circular(50.0),
@@ -91,7 +91,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
               right: 100.0,
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
-                  primary: Theme.of(context).colorScheme.secondary,
+                  backgroundColor: Theme.of(context).colorScheme.secondary,
                   shape: StadiumBorder(),
                   padding: EdgeInsets.symmetric(vertical: 15),
                 ),

--- a/lib/widgets/login_form.dart
+++ b/lib/widgets/login_form.dart
@@ -173,8 +173,7 @@ class _LoginFormState extends State<LoginForm> {
                           padding: EdgeInsets.symmetric(
                               vertical: 15,
                               horizontal:
-                                  (MediaQuery.of(context).size.width / 8) - 10),
-                          primary: Colors.white,
+                                  (MediaQuery.of(context).size.width / 8) - 10), backgroundColor: Colors.white,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadiusDirectional.circular(30),
                           ),
@@ -201,8 +200,7 @@ class _LoginFormState extends State<LoginForm> {
                           padding: EdgeInsets.symmetric(
                               vertical: 15,
                               horizontal:
-                                  (MediaQuery.of(context).size.width / 8) - 10),
-                          primary: kAuthThemeColor,
+                                  (MediaQuery.of(context).size.width / 8) - 10), backgroundColor: kAuthThemeColor,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadiusDirectional.circular(30),
                           ),

--- a/lib/widgets/recents_homeworks.dart
+++ b/lib/widgets/recents_homeworks.dart
@@ -119,8 +119,7 @@ class _RecentHomeworksState extends State<RecentHomeworks> {
       style: ElevatedButton.styleFrom(
         shape: CircleBorder(
           side: BorderSide(color: Theme.of(context).colorScheme.secondary),
-        ),
-        primary: homework.isDone
+        ), backgroundColor: homework.isDone
             ? Theme.of(context).colorScheme.secondary
             : Colors.transparent,
       ),

--- a/lib/widgets/reset_password.dart
+++ b/lib/widgets/reset_password.dart
@@ -19,7 +19,7 @@ class _ResetScreenState extends State<ResetScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: SafeArea(
         child: Stack(
           children: [
@@ -72,8 +72,7 @@ class _ResetScreenState extends State<ResetScreen> {
                 Center(
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      shape: StadiumBorder(),
-                      primary: Theme.of(context).colorScheme.secondary,
+                      shape: StadiumBorder(), backgroundColor: Theme.of(context).colorScheme.secondary,
                     ),
                     onPressed: () {
                       if (!emailValid) {

--- a/lib/widgets/round_button.dart
+++ b/lib/widgets/round_button.dart
@@ -15,8 +15,7 @@ class RoundButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ElevatedButton(
       style: ElevatedButton.styleFrom(
-        padding: EdgeInsets.symmetric(vertical: 15, horizontal: 40),
-        primary: color, //kAuthThemeColor
+        padding: EdgeInsets.symmetric(vertical: 15, horizontal: 40), backgroundColor: color, //kAuthThemeColor
         shape: RoundedRectangleBorder(
             borderRadius: BorderRadiusDirectional.circular(30)),
       ),

--- a/lib/widgets/signup_form_additional_details.dart
+++ b/lib/widgets/signup_form_additional_details.dart
@@ -246,8 +246,7 @@ class _SignUpFormAdditionalDetailsState
                         ElevatedButton(
                           style: ElevatedButton.styleFrom(
                             padding: EdgeInsets.symmetric(
-                                vertical: 13, horizontal: 20),
-                            primary: kAuthThemeColor,
+                                vertical: 13, horizontal: 20), backgroundColor: kAuthThemeColor,
                             shape: RoundedRectangleBorder(
                               borderRadius:
                                   BorderRadiusDirectional.circular(30),
@@ -594,7 +593,7 @@ class _SignUpFormAdditionalDetailsState
           _course = value!;
         });
       },
-      dropdownColor: Theme.of(context).backgroundColor,
+      dropdownColor: Theme.of(context).colorScheme.background,
       decoration: dropdownDecoration.copyWith(labelText: 'Course'),
       items: _coursesList.map<DropdownMenuItem<String>>(
         (String value) {
@@ -720,7 +719,7 @@ class _SignUpFormAdditionalDetailsState
           _department = value!;
         });
       },
-      dropdownColor: Theme.of(context).backgroundColor,
+      dropdownColor: Theme.of(context).colorScheme.background,
       decoration: dropdownDecoration.copyWith(labelText: 'Department/Major'),
       items: _departmentList.map<DropdownMenuItem<String>>(
         (String value) {
@@ -754,7 +753,7 @@ class _SignUpFormAdditionalDetailsState
           _gen = gender!;
         });
       },
-      dropdownColor: Theme.of(context).backgroundColor,
+      dropdownColor: Theme.of(context).colorScheme.background,
       decoration: dropdownDecoration.copyWith(
         labelText: "Gender",
       ),

--- a/lib/widgets/signup_form_essential_details.dart
+++ b/lib/widgets/signup_form_essential_details.dart
@@ -212,8 +212,7 @@ class _SignUpFormEssentialDetailsState
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
                       padding:
-                          EdgeInsets.symmetric(vertical: 13, horizontal: 20),
-                      primary: kAuthThemeColor,
+                          EdgeInsets.symmetric(vertical: 13, horizontal: 20), backgroundColor: kAuthThemeColor,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadiusDirectional.circular(30),
                       ),


### PR DESCRIPTION
# Description

The use of 'backgroundColor' is no longer recommended and should be avoided. Instead, it is advised to utilize the 'colorScheme.background' property as a suitable replacement and I also do some replacement in code for better use.

## Fixes #305 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

-  Yes
- [ ] No

## Type of change

-  Bug fix 

## Checklist:

-  My code follows the style guidelines(Clean Code) of this project
-  I have performed a self-review of my own code
-  My changes generate no new warnings
-  I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
