### PR TITLE
docs: make gssoc banner adaptable to light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,10 @@ Thanks to these wonderful people.
 Contributions of any kind are welcome!
   
 ## Open Source Programs _Friday_ has been Part of 🚀
-	
-<a href="https://gssoc.girlscript.tech/">
+<div align=center>
   <img alt="GSSoC" src="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png#gh-light-mode-only" width=87%>
   <img alt="GSSoC" src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png#gh-dark-mode-only"/>
-</a>
- 
+</div>
 <h1 align=center> Project Admin ❤️ </h1>
 <p align="center">
   <a href="https://github.com/avinashkranjan"><img src="https://user-images.githubusercontent.com/55796944/95675026-dab07580-0bd1-11eb-93e2-1cb1de8acf38.png" width=150px height=150px /></a> 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ Contributions of any kind are welcome!
   
 ## Open Source Programs _Friday_ has been Part of 🚀
 	
- <a>
-	 
- [<img src="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png">](https://gssoc.girlscript.tech/)
-	 
+<a href="https://gssoc.girlscript.tech/">
+  <img alt="GSSoC" src="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png#gh-light-mode-only" width=87%>
+  <img alt="GSSoC" src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png#gh-dark-mode-only"/>
+</a>
+ 
 <h1 align=center> Project Admin ❤️ </h1>
 <p align="center">
   <a href="https://github.com/avinashkranjan"><img src="https://user-images.githubusercontent.com/55796944/95675026-dab07580-0bd1-11eb-93e2-1cb1de8acf38.png" width=150px height=150px /></a> 


### PR DESCRIPTION
# Description
- This PR is about making the GSSoC Banner adaptable for Dark/Light Mode of Github.
- The banner will be swapped according to the theme preference, it uses Github's inbuilt functionality.

# Fixes #325 

<hr>

# Screenshots
| WITHOUT USING GITHUB'S FEATURE |
| :--: |
| ![](https://github.com/avinashkranjan/Friday/assets/92252895/dadc7406-b309-4f5a-bc21-be6d828cde3b) |


<br>

<div align=center>

**AFTER USING GITHUB'S FEATURE**

</div>

| DARK THEME | LIGHT THEME |
| :--: | :---: |
| ![](https://github.com/avinashkranjan/Friday/assets/92252895/b6c38ecf-e99b-431c-8eeb-3e4b9f09ab12) | ![](https://github.com/avinashkranjan/Friday/assets/92252895/c4a199bd-ee21-473e-9b67-a579b4977fb6)|

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [x] Documentation

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
