### PR TITLE
Removed dual calenders in build_classes screen

### DIFF
--- a/lib/widgets/build_classes.dart
+++ b/lib/widgets/build_classes.dart
@@ -128,31 +128,32 @@ class _BuildClassesState extends State<BuildClasses> {
     return SingleChildScrollView(
       child: Column(
         children: [
+
           Card(shape: RoundedRectangleBorder(
 
 
-      borderRadius: BorderRadius.all(Radius.circular(20))
-    ),color: Colors.white12,
+              borderRadius: BorderRadius.all(Radius.circular(20))
+          ),color: Colors.white12,
 
             child:
-          TableCalendar<Classes>(
-            onFormatChanged: (format) {},
-            firstDay: DateTime.utc(2002),
-            lastDay: DateTime.utc(2024),
-            focusedDay: _focusedDay,
-            selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
-            eventLoader: _getEventsForDay,
-            onDaySelected: _onDaySelected,
+            TableCalendar<Classes>(
+              onFormatChanged: (format) {},
+              firstDay: DateTime.utc(2002),
+              lastDay: DateTime.utc(2024),
+              focusedDay: _focusedDay,
+              selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
+              eventLoader: _getEventsForDay,
+              onDaySelected: _onDaySelected,
 
-            calendarStyle: CalendarStyle(
-             disabledTextStyle: TextStyle(color: Colors.white),
-              weekNumberTextStyle: TextStyle(color: Theme.of(context).primaryColor),
-              markerDecoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: Colors.amber,
+              calendarStyle: CalendarStyle(
+                disabledTextStyle: TextStyle(color: Colors.white),
+                weekNumberTextStyle: TextStyle(color: Theme.of(context).primaryColor),
+                markerDecoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.amber,
+                ),
               ),
-            ),
-          ),),
+            ),),
 
 
           classesList != null && classesList.isNotEmpty


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

I've removed the dual calenders issue in the ```build_classes.dart``` screen. Also, I adjusted the UI opf the screen for single calender display. 

## Fixes #419 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Friday/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
